### PR TITLE
Don't init InfoPackageManager twice

### DIFF
--- a/read.g
+++ b/read.g
@@ -4,6 +4,4 @@
 # Reading the implementation part of the package.
 #
 
-SetInfoLevel(InfoPackageManager, 1);
-
 ReadPackage("PackageManager", "gap/PackageManager.gi");


### PR DESCRIPTION
It is already being set in gap/PackageManager.gd