### PR TITLE
Tweak README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,12 @@ A basic collection of simple functions for installing and removing GAP packages,
 with the eventual aim of becoming a full pip-style package manager for the GAP
 language.
 
-Example code:
-```gap
-gap> InstallPackage("digraphs");
+Example invocations:
 
-gap> InstallPackage("https://github.com/gap-packages/Semigroups.git");
+    gap> InstallPackage("digraphs");
 
-gap> InstallPackage("https://www.gap-system.org/pub/gap/gap4/tar.gz/packages/mapclass-1.2.tar.gz");
-```
+    gap> InstallPackage("https://github.com/gap-packages/Semigroups.git");
+
+    gap> InstallPackage("https://www.gap-system.org/pub/gap/gap4/tar.gz/packages/mapclass-1.2.tar.gz");
 
 Please take care when using the `RemovePackage` function.


### PR DESCRIPTION
READMEs often are read by people in a text editor or a shell pager,
without rendering. There, using indentation to mark text as code
is easier to read for the human, compared to when ``` is used.